### PR TITLE
Update default channel for local-storage-operator to `stable`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,6 +4,6 @@ parameters:
     namespace: openshift-local-storage
 
     local_storage_operator:
-      channel: "4.7"
+      channel: "stable"
 
     local_volumes: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,8 +15,7 @@ Defaults to the suggested namespace for the RedHat Local Storage operator.
 
 [horizontal]
 type:: string
-default:: `"4.7"`
-example:: `"${dynamic_facts:openshiftVersion:Major}.${dynamic_facts:openshiftVersion:Minor}"`
+default:: `stable`
 
 The subscription channel to use when installing the Local Storage Operator using the Operator Lifecycle Manager.
 

--- a/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/20_olm_subscription.yaml
+++ b/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/20_olm_subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-  channel: '4.7'
+  channel: stable
   installPlanApproval: Automatic
   name: local-storage-operator
   source: redhat-operators


### PR DESCRIPTION
Looks like there's no `4.11` channel, despite what the upstream documentation suggests.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
