### PR TITLE
Prune the subscription resource to prevent emtpy annotations

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -33,13 +33,13 @@ local operatorGroup = operatorlib.OperatorGroup('openshift-local-storage') {
   },
 };
 
-local subscription = operatorlib.namespacedSubscription(
+local subscription = std.prune(operatorlib.namespacedSubscription(
   params.namespace,
   'local-storage-operator',
   params.local_storage_operator.channel,
   'redhat-operators',
   'openshift-marketplace'
-);
+));
 
 local lvs = import 'localvolumes.libsonnet';
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -22,7 +22,15 @@ local namespace = {
   },
 };
 
-local operatorGroup = operatorlib.OperatorGroup('openshift-local-storage') {
+// Hides the .metadata.annotations field if empty for SSA compatibility
+local hideAnnotations = function(obj)
+  obj {
+    metadata+: {
+      [if std.length(std.get(obj.metadata, 'annotations', {})) == 0 then 'annotations']+:: {},
+    },
+  };
+
+local operatorGroup = hideAnnotations(operatorlib.OperatorGroup('openshift-local-storage')) {
   metadata+: {
     namespace: params.namespace,
   },
@@ -33,7 +41,7 @@ local operatorGroup = operatorlib.OperatorGroup('openshift-local-storage') {
   },
 };
 
-local subscription = std.prune(operatorlib.namespacedSubscription(
+local subscription = hideAnnotations(operatorlib.namespacedSubscription(
   params.namespace,
   'local-storage-operator',
   params.local_storage_operator.channel,

--- a/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/10_operator_group.yaml
+++ b/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/10_operator_group.yaml
@@ -1,7 +1,6 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations: {}
   labels:
     name: openshift-local-storage
   name: openshift-local-storage

--- a/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/20_olm_subscription.yaml
+++ b/tests/golden/defaults/openshift4-local-storage/openshift4-local-storage/20_olm_subscription.yaml
@@ -1,7 +1,6 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  annotations: {}
   labels:
     name: local-storage-operator
   name: local-storage-operator


### PR DESCRIPTION
Empty annotations cause OutOfSync errors in ArgoCD




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
